### PR TITLE
🔧 Disable required headings for markdown lint

### DIFF
--- a/.github/workflows/configs/.markdownlint.yaml
+++ b/.github/workflows/configs/.markdownlint.yaml
@@ -198,11 +198,11 @@ MD041:
 MD042: true
 
 # MD043/required-headings : Required heading structure
-MD043:
-  # List of headings
-  headings: []
-  # Match case of headings
-  match_case: false
+MD043: false
+  # # List of headings
+  # headings: []
+  # # Match case of headings
+  # match_case: false
 
 # MD044/proper-names : Proper names should have the correct capitalization
 MD044:


### PR DESCRIPTION
## 🔍 Samenvatting

Deze PR zet setting `MD043` om van `true` naar `false` zodat de workflow `Markdown Lint` niet meer controleert of alle markdown files de juiste header structuur hebben.
Door deze setting was het niet mogelijk om een markdown file te beginnen met `## heading` zonder dat deze een `# heading` erboven heeft

Zie: https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md043.md

## 📝 Beschrijving

<!-- Beschrijf in detail en puntsgewijs wat je aangepast hebt. -->

- In `.markdownlint.yaml` is de configuratie voor `MD043` aangepast naar `false`