### PR TITLE
✨ Add a template chooser to pick PR template manually

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,17 @@
-## Choose a Pull Request template
+# Choose a Pull Request template
 
 1. Click the `Preview` tab above.
 2. Select the most appropriate template for your PR from the list below:
 
 ---
 
-**General Templates**
+## **General Templates
+
 - [📑 General PR (Short)](?expand=1&template=general-small.md)
 - [📑 General PR (Extended)](?expand=1&template=general-extended.md)
 
-**Specific templates**
+## Specific templates
+
 - [📝 Documentation](?expand=1&template=documentation.md)
 - [✨ Feature](?expand=1&template=feature.md)
 - [🐛 Fix](?expand=1&template=fix.md)


### PR DESCRIPTION
## 🔍 Samenvatting

Deze PR voegt een standaard Pull Request template toe. Deze fungeert als een template chooser.

_Github ondersteunt wel meerdere PR templates, maar heeft geen UI waarmee je dit kunt selecteren ([Feature request](https://github.com/orgs/community/discussions/4620)).
Het is mogelijk dit te omzeilen door van de PR templates een link te maken ([Oplossing hier](https://github.com/orgs/community/discussions/4620#discussioncomment-3383383))_

## 📝 Beschrijving

- Standaard Pull Request template toegevoegd die fungeert als een template chooser

## ✅ Checklist
- [x] Code is lokaal getest