### PR TITLE
🔥 Remove configuration section from PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation.md
@@ -1,10 +1,3 @@
----
-name: Documentatie bijgewerkt
-about: Template voor documentatie wijzigingen
-title: "📝 [ACTION] [WHAT] in/for [WHERE]"
-labels: 'type: documentation'
----
-
 ## 🔍 Samenvatting
 
 <!-- Geef een korte beschrijving van deze wijziging (1-3 zinnen) -->

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,10 +1,3 @@
----
-name: Nieuwe functionaliteit
-about: Template voor het toevoegen van een nieuwe functionaliteit
-title: "✨ [ACTION] [WHAT] in/for [WHERE]"
-labels: 'type: feature'
----
-
 ## 🔍 Samenvatting
 
 <!-- Geef een korte beschrijving van wat je hebt toegevoegd (1-3 zinnen) -->

--- a/.github/PULL_REQUEST_TEMPLATE/fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fix.md
@@ -1,10 +1,3 @@
----
-name: Fix
-about: Template voor het oplossen van een probleem
-title: "🩹🐛🚑 [ACTION] [WHAT] in/for [WHERE]"
-labels: 'type: fix'
----
-
 ## 🔍 Samenvatting
 
 <!-- Geef een korte beschrijving van deze wijziging (1-3 zinnen) -->

--- a/.github/PULL_REQUEST_TEMPLATE/general-extended.md
+++ b/.github/PULL_REQUEST_TEMPLATE/general-extended.md
@@ -1,10 +1,3 @@
----
-name: Algemeen (uitgebreid)
-about: Template voor overige Pull Requests
-title: "🎨 [ACTION] [WHAT] in/for [WHERE]"
-labels: 'type: other'
----
-
 ## 🔍 Samenvatting
 
 <!-- Geef een korte beschrijving van deze wijziging (1-3 zinnen) -->

--- a/.github/PULL_REQUEST_TEMPLATE/general-small.md
+++ b/.github/PULL_REQUEST_TEMPLATE/general-small.md
@@ -1,10 +1,3 @@
----
-name: Algemeen (kort)
-about: Template voor overige Pull Requests
-title: "🎨 [ACTION] [WHAT] in/for [WHERE]"
-labels: 'type: other'
----
-
 ## 🔍 Samenvatting
 
 <!-- Geef een korte beschrijving van deze wijziging (1-3 zinnen) -->

--- a/.github/PULL_REQUEST_TEMPLATE/refactor.md
+++ b/.github/PULL_REQUEST_TEMPLATE/refactor.md
@@ -1,10 +1,3 @@
----
-name: Refactor
-about: Template voor refactor wijzigingen
-title: "♻️ [ACTION] [WHAT] in/for [WHERE]"
-labels: 'type: refactor'
----
-
 ## 🔍 Samenvatting
 
 <!-- Geef een korte beschrijving van deze wijziging (1-3 zinnen) -->


### PR DESCRIPTION
## 🔍 Samenvatting

Deze PR verwijdert de configuratie uit de Pull Request templates. Dit was in eerste instantie overgenomen uit de issue templates, maar blijkbaar wordt configuratie helemaal niet ondersteund voor PR templates.

## 📝 Beschrijving

- Configuratie sectie verwijderd uit alle PR templates

## ✅ Checklist

- [ ] Code is lokaal getest
- [ ] Tests toegevoegd
- [ ] Documentatie bijgewerkt (indien nodig)