### PR TITLE
👷 Use self hosted runners for label-sync workflow

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   label-sync:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Determine repository type from custom properties
         id: determine-type


### PR DESCRIPTION
## 🔍 Samenvatting

Deze PR past de `label-sync` workflow aan zodat deze wordt uitgevoerd op onze eigen runners

## ✅ Checklist

- [ ] Code is lokaal getest
- [ ] Tests zijn toegevoegd/aangepast
- [ ] Documentatie bijgewerkt (indien nodig)
