### PR TITLE
🔧 Add new endpoint label for backend repos

### DIFF
--- a/labels/backend.yml
+++ b/labels/backend.yml
@@ -10,3 +10,8 @@
   color: "#2E8B57"
   description: "Database schema, queries, or migrations"
   aliases: []
+
+- name: "type: endpoint"
+  color: "#8B572E"
+  description: "Endpoint implementation or changes"
+  aliases: ["🔗 endpoint"]


### PR DESCRIPTION
## 🔍 Samenvatting

Deze PR voegt een nieuwe label `type: endpoint` toe voor backend repositories en vervangt daarmee de huidige `🔗 endpoint` label.

Dit label zou samengevoegd kunnen worden met `type: feature`, maar ik denk persoonlijk dat het handig is om de nieuwe endpoints apart te benoemen in de Release Notes. Deze worden namelijk automatisch gegenereerd op basis van labels
