### PR TITLE
🔧 Set correct label alias for architecture

### DIFF
--- a/labels/general.yml
+++ b/labels/general.yml
@@ -54,7 +54,7 @@
 - name: "type: architecture"
   color: "#6A4FB6"
   description: "Application architecture and high-level design"
-  aliases: []
+  aliases: ["🏗️ architecture"]
 
 ########################################################
 # Size/Effort Labels


### PR DESCRIPTION
## 🔍 Samenvatting

Deze PR voegt de oude label `🏗️ architecture` toe als alias van de nieuwe `type: architecture` zodat ze tijdens de `label-sync` workflow goed vervangen worden.
