### PR TITLE
🔧 For monorepo use both frontend and backend labels

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -48,6 +48,9 @@ jobs:
             "backend")
               CONFIG_FILES="$CONFIG_FILES"$'\n'"$BASE_URL/backend.yml"
               ;;
+            "monorepo")
+              CONFIG_FILES="$CONFIG_FILES"$'\n'"$BASE_URL/frontend.yml"$'\n'"$BASE_URL/backend.yml"
+              ;;
             *)
               echo "Unknown repo type '$REPO_TYPE', using only general labels"
               ;;


### PR DESCRIPTION
## 🔍 Samenvatting

Deze PR voegt label configuratie toe voor monorepo's waardoor meer bruikbare labels worden toegevoegd aan de repository

## 📝 Beschrijving

- Als de `codebase_type` van een repository is ingesteld op `monorepo`, dan moeten zowel `general.yaml`, `frontend.yaml` en `backend.yaml` ingeladen worden

## ✅ Checklist

- [ ] Code is lokaal getest
- [ ] Tests zijn toegevoegd/aangepast
- [ ] Documentatie bijgewerkt (indien nodig)
