### PR TITLE
👷 Update workflows to use brixion-runner for Github Actions

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   label-sync:
-    runs-on: self-hosted
+    runs-on: brixion-runners
     steps:
       - name: Determine repository type from custom properties
         id: determine-type

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -11,7 +11,7 @@ on: # yamllint disable-line rule:truthy
 jobs:
     lint-markdown:
         name: Lint Markdown
-        runs-on: self-hosted
+        runs-on: brixion-runners
         steps:
             - uses: actions/checkout@v4  # Checkout the calling repo
 


### PR DESCRIPTION
## 🔍 Samenvatting

Deze PR past de `runs-on` in de workflows aan naar `brixion-runners` zodat onze eigen Github Action runners worden gebruikt.

## ✅ Checklist

- [ ] Code is lokaal getest
- [ ] Tests zijn toegevoegd/aangepast
- [ ] Documentatie bijgewerkt (indien nodig)
