### PR TITLE
👷 Runs on ubuntu latest

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   label-sync:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Determine repository type from custom properties
         id: determine-type

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -11,7 +11,7 @@ on: # yamllint disable-line rule:truthy
 jobs:
     lint-markdown:
         name: Lint Markdown
-        runs-on: self-hosted
+        runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4  # Checkout the calling repo
 


### PR DESCRIPTION
## 🔍 Samenvatting

<!-- Geef een korte beschrijving van deze wijziging (1-3 zinnen) -->

Deze PR past de Github Actions workflows aan om ze te draaien op `ubuntu-latest` omdat onze `self-hosted` runners niet meer in de lucht zijn. [Omdat dit een public branch is kunnen we hier niet onze eigen Kubernetes runners gebruiken](https://stackoverflow.com/questions/77179987/is-it-really-unsafe-to-use-a-github-self-hosted-runner-on-a-own-public-repositor).

## 📝 Beschrijving

- `runs-on` in alle bestanden aangepast naar `ubuntu-latest`

## ✅ Checklist

- [x] Code is lokaal getest
- [ ] Tests zijn toegevoegd/aangepast
- [ ] Documentatie bijgewerkt (indien nodig)
