### PR TITLE
🔧 Redefine size label descriptions from time to complexity

### DIFF
--- a/labels/general.yml
+++ b/labels/general.yml
@@ -61,27 +61,27 @@
 ########################################################
 - name: "size: XS"
   color: "#00345E"
-  description: "Very small task (< 15 minutes)"
+  description: "Trivial work. Clear, low risk, no coordination needed."
   aliases: ["XS"]
 
 - name: "size: S"
   color: "#004277"
-  description: "Small task (< 1 hour)"
+  description: "Simple work. Known pattern, low uncertainty."
   aliases: ["S"]
 
 - name: "size: M"
   color: "#005091"
-  description: "Medium task (1-4 hours)"
+  description: "Moderate complexity. Multiple steps or small decisions."
   aliases: ["M"]
 
 - name: "size: L"
   color: "#005EAA"
-  description: "Large task (1-8 hours)"
+  description: "High complexity. Multiple parts, risks or dependencies."
   aliases: ["L"]
 
 - name: "size: XL"
   color: "#006CC4"
-  description: "Very large task (> 1 day)"
+  description: "Too complex or unclear. Split or run a spike first."
   aliases: ["XL"]
 
 ########################################################


### PR DESCRIPTION
## 🔍 Samenvatting

Deze PR herdefiniëert de size labels van tijd naar complexiteit

### Waarom

Onze size labels waren gekoppeld aan tijd (uren/minuten).
Dat zorgt voor schijnnauwkeurigheid, onnodige discussies en defensief inschatten.

We stappen daarom over naar **sizes op basis van complexiteit en onzekerheid**, niet op tijd.
Dit past beter bij hoe we werken en hoe ons werk zich in de praktijk gedraagt.

---

### Wat verandert

* Tijdsaanduidingen zijn verwijderd uit alle size labels
* Sizes beschrijven nu:

  * complexiteit
  * risico
  * mate van duidelijkheid
* `size: XL` is expliciet een **signaal** geworden:

  * te onzeker of te groot
  * eerst opsplitsen of een spike uitvoeren
  * **niet direct bouwen**

De labels zelf blijven hetzelfde (`XS / S / M / L / XL`), alleen de betekenis verandert.
